### PR TITLE
Add ZipVoice config bindings to Swift TTS wrapper

### DIFF
--- a/swift-api-examples/SherpaOnnx.swift
+++ b/swift-api-examples/SherpaOnnx.swift
@@ -916,6 +916,32 @@ func sherpaOnnxOfflineTtsKittenModelConfig(
   )
 }
 
+func sherpaOnnxOfflineTtsZipvoiceModelConfig(
+  tokens: String = "",
+  textModel: String = "",
+  flowMatchingModel: String = "",
+  vocoder: String = "",
+  dataDir: String = "",
+  pinyinDict: String = "",
+  featScale: Float = 0.1,
+  tShift: Float = 0.5,
+  targetRms: Float = 0.1,
+  guidanceScale: Float = 1.0
+) -> SherpaOnnxOfflineTtsZipvoiceModelConfig {
+  return SherpaOnnxOfflineTtsZipvoiceModelConfig(
+    tokens: toCPointer(tokens),
+    text_model: toCPointer(textModel),
+    flow_matching_model: toCPointer(flowMatchingModel),
+    vocoder: toCPointer(vocoder),
+    data_dir: toCPointer(dataDir),
+    pinyin_dict: toCPointer(pinyinDict),
+    feat_scale: featScale,
+    t_shift: tShift,
+    target_rms: targetRms,
+    guidance_scale: guidanceScale
+  )
+}
+
 func sherpaOnnxOfflineTtsModelConfig(
   vits: SherpaOnnxOfflineTtsVitsModelConfig = sherpaOnnxOfflineTtsVitsModelConfig(),
   matcha: SherpaOnnxOfflineTtsMatchaModelConfig = sherpaOnnxOfflineTtsMatchaModelConfig(),
@@ -923,7 +949,8 @@ func sherpaOnnxOfflineTtsModelConfig(
   numThreads: Int = 1,
   debug: Int = 0,
   provider: String = "cpu",
-  kitten: SherpaOnnxOfflineTtsKittenModelConfig = sherpaOnnxOfflineTtsKittenModelConfig()
+  kitten: SherpaOnnxOfflineTtsKittenModelConfig = sherpaOnnxOfflineTtsKittenModelConfig(),
+  zipvoice: SherpaOnnxOfflineTtsZipvoiceModelConfig = sherpaOnnxOfflineTtsZipvoiceModelConfig()
 ) -> SherpaOnnxOfflineTtsModelConfig {
   return SherpaOnnxOfflineTtsModelConfig(
     vits: vits,
@@ -932,7 +959,8 @@ func sherpaOnnxOfflineTtsModelConfig(
     provider: toCPointer(provider),
     matcha: matcha,
     kokoro: kokoro,
-    kitten: kitten
+    kitten: kitten,
+    zipvoice: zipvoice
   )
 }
 


### PR DESCRIPTION
## Summary
- add a Swift helper that builds `SherpaOnnxOfflineTtsZipvoiceModelConfig`
- extend the Swift TTS model configuration factory to accept and pass along the ZipVoice configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8c5f993c8332ac3b64c0d03c45cc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Swift builder for `SherpaOnnxOfflineTtsZipvoiceModelConfig` and threads it through `sherpaOnnxOfflineTtsModelConfig`.
> 
> - **Offline TTS (Swift)** in `swift-api-examples/SherpaOnnx.swift`:
>   - **New config builder**: `sherpaOnnxOfflineTtsZipvoiceModelConfig(...)` creating `SherpaOnnxOfflineTtsZipvoiceModelConfig` with fields `tokens`, `text_model`, `flow_matching_model`, `vocoder`, `data_dir`, `pinyin_dict`, `feat_scale`, `t_shift`, `target_rms`, `guidance_scale`.
>   - **Model factory update**: `sherpaOnnxOfflineTtsModelConfig(...)` now accepts `zipvoice` and forwards it to `SherpaOnnxOfflineTtsModelConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1c8c414d6d81f6ccb1fcdbdd07ef2972c91a3b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->